### PR TITLE
Update galaxy_eyes_cipher_dragon.json

### DIFF
--- a/ydm_db/cards/galaxy_eyes_cipher_dragon.json
+++ b/ydm_db/cards/galaxy_eyes_cipher_dragon.json
@@ -7,7 +7,7 @@
   "images": [
     "https://images.ygoprodeck.com/images/cards/18963306.jpg"
     "https://cdn.discordapp.com/attachments/1187789172015112363/1267531801971392555/image.png?ex=66a9c93b&is=66a877bb&hm=0998aadd720869f3a030aa38471ec600f36b7c6ecfe411cdc2302bf599ee37ef&"
-  ],
+  ]
   "type": "Monster",
   "attribute": "LIGHT",
   "atk": 3000,


### PR DESCRIPTION
Tried fixing it let's see if it works. It's the alt art for Cipher Dragon. Might have been bc of the comma at the end. If it doesn't work just remove the alt art